### PR TITLE
Adding `contentMaxWidth` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- feature: Added `contentMaxWidth` prop to `InfoPopupWidget`
+
 ## 2.1.3
 
 - doc: Update README.md

--- a/lib/src/controllers/info_popup_controller.dart
+++ b/lib/src/controllers/info_popup_controller.dart
@@ -24,6 +24,7 @@ class InfoPopupController {
     this.onLayoutMounted,
     this.contentOffset = Offset.zero,
     this.indicatorOffset = Offset.zero,
+    this.contentMaxWidth,
   }) : _targetRenderBox = targetRenderBox;
 
   /// The [layerLink] is the layer link of the popup.
@@ -74,6 +75,11 @@ class InfoPopupController {
   /// The [infoPopupContainerSize] is the size of the popup.
   Size? infoPopupContainerSize;
 
+  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// If the [contentMaxWidth] is null, the max width will be eighty percent
+  /// of the screen.
+  final double? contentMaxWidth;
+
   /// The [show] method is used to show the popup.
   void show() {
     _infoPopupOverlayEntry = OverlayEntry(
@@ -88,6 +94,8 @@ class InfoPopupController {
           contentTheme: contentTheme,
           contentOffset: contentOffset,
           indicatorOffset: indicatorOffset,
+          dismissTriggerBehavior: dismissTriggerBehavior,
+          contentMaxWidth: contentMaxWidth,
           onLayoutMounted: (Size size) {
             Future<void>.delayed(
               const Duration(milliseconds: 30),
@@ -109,7 +117,6 @@ class InfoPopupController {
 
             dismissInfoPopup();
           },
-          dismissTriggerBehavior: dismissTriggerBehavior,
         );
       },
     );

--- a/lib/src/controllers/info_popup_controller.dart
+++ b/lib/src/controllers/info_popup_controller.dart
@@ -75,7 +75,7 @@ class InfoPopupController {
   /// The [infoPopupContainerSize] is the size of the popup.
   Size? infoPopupContainerSize;
 
-  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// [contentMaxWidth] is the max width of the content that is shown.
   /// If the [contentMaxWidth] is null, the max width will be eighty percent
   /// of the screen.
   final double? contentMaxWidth;

--- a/lib/src/info_popup_widget.dart
+++ b/lib/src/info_popup_widget.dart
@@ -19,6 +19,7 @@ class InfoPopupWidget extends StatefulWidget {
     this.dismissTriggerBehavior = PopupDismissTriggerBehavior.onTapArea,
     this.contentOffset,
     this.indicatorOffset,
+    this.contentMaxWidth,
     super.key,
   }) : assert(customContent == null || contentTitle == null,
             'You can not use both customContent and contentTitle at the same time.');
@@ -61,6 +62,11 @@ class InfoPopupWidget extends StatefulWidget {
 
   /// The [indicatorOffset] is the offset of the indicator.
   final Offset? indicatorOffset;
+
+  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// If the [contentMaxWidth] is null, the max width will be eighty percent
+  /// of the screen.
+  final double? contentMaxWidth;
 
   @override
   State<InfoPopupWidget> createState() => _InfoPopupWidgetState();
@@ -129,6 +135,7 @@ class _InfoPopupWidgetState extends State<InfoPopupWidget> {
       infoPopupDismissed: widget.infoPopupDismissed,
       contentOffset: widget.contentOffset ?? const Offset(0, 0),
       indicatorOffset: widget.indicatorOffset ?? const Offset(0, 0),
+      contentMaxWidth: widget.contentMaxWidth,
     );
 
     if (!_isControllerInitialized && widget.onControllerCreated != null) {

--- a/lib/src/info_popup_widget.dart
+++ b/lib/src/info_popup_widget.dart
@@ -63,7 +63,7 @@ class InfoPopupWidget extends StatefulWidget {
   /// The [indicatorOffset] is the offset of the indicator.
   final Offset? indicatorOffset;
 
-  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// [contentMaxWidth] is the max width of the content that is shown.
   /// If the [contentMaxWidth] is null, the max width will be eighty percent
   /// of the screen.
   final double? contentMaxWidth;

--- a/lib/src/overlays/overlay_entry_layout.dart
+++ b/lib/src/overlays/overlay_entry_layout.dart
@@ -56,7 +56,7 @@ class OverlayInfoPopup extends StatefulWidget {
   /// [dismissTriggerBehavior] is the behavior of the popup when the popup is pressed.
   final PopupDismissTriggerBehavior dismissTriggerBehavior;
 
-  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// [contentMaxWidth] is the max width of the content that is shown.
   /// If the [contentMaxWidth] is null, the max width will be eighty percent
   /// of the screen.
   final double? contentMaxWidth;

--- a/lib/src/overlays/overlay_entry_layout.dart
+++ b/lib/src/overlays/overlay_entry_layout.dart
@@ -16,6 +16,7 @@ class OverlayInfoPopup extends StatefulWidget {
     required this.indicatorOffset,
     required this.contentOffset,
     required this.dismissTriggerBehavior,
+    required this.contentMaxWidth,
     super.key,
   });
 
@@ -54,6 +55,11 @@ class OverlayInfoPopup extends StatefulWidget {
 
   /// [dismissTriggerBehavior] is the behavior of the popup when the popup is pressed.
   final PopupDismissTriggerBehavior dismissTriggerBehavior;
+
+  /// [contentMaxWidth] is the max width of the content that is being showed.
+  /// If the [contentMaxWidth] is null, the max width will be eighty percent
+  /// of the screen.
+  final double? contentMaxWidth;
 
   @override
   State<OverlayInfoPopup> createState() => _OverlayInfoPopupState();
@@ -183,6 +189,14 @@ class _OverlayInfoPopupState extends State<OverlayInfoPopup> {
     );
   }
 
+  double get _contentMaxWidth {
+    if (widget.contentMaxWidth == null) {
+      return context.screenWidth * .8;
+    } else {
+      return widget.contentMaxWidth!;
+    }
+  }
+
   double get _contentMaxHeight {
     const int padding = 16;
     final double screenHeight = context.screenHeight;
@@ -263,7 +277,7 @@ class _OverlayInfoPopupState extends State<OverlayInfoPopup> {
                         scale: _isLayoutDone ? 1.0 : 0.0,
                         child: ConstrainedBox(
                           constraints: BoxConstraints(
-                            maxWidth: context.screenWidth * .8,
+                            maxWidth: _contentMaxWidth,
                             maxHeight: _contentMaxHeight,
                           ),
                           child: Container(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: info_popup
 description: The simple way to show the user some information on your selected widget.
-version: 2.1.3
+version: 2.2.0
 repository: https://github.com/salihcanbinboga/info_popup
 
 environment:
   sdk: '>=2.17.3 <3.0.0'
-  flutter: ">=1.17.0"
+  flutter: '>=1.17.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR adds a nullable parameter called `contentMaxWidth` to override the content's max width if it is not null. This is useful when the developer needs more than eighty percent of the visible screen.